### PR TITLE
Fix typo in admin header

### DIFF
--- a/backend/admin.py
+++ b/backend/admin.py
@@ -7,7 +7,7 @@ class ProductoAdmin(admin.ModelAdmin):
     search_fields = ('nombre', 'categoria')
     list_filter = ('categoria',)
 
-admin.site.site_header = " Administración Centro de Bienetsar  "
+admin.site.site_header = "Administración Centro de Bienestar"
 admin.site.site_title = "Administrador"
 admin.site.index_title = "Bienvenido al Panel de Administración Premium de GoToGym"
 


### PR DESCRIPTION
## Summary
- correct spacing in admin header name

## Testing
- `pytest -q`
- `python backend/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684097681d708332bb8e8a074387c430