### PR TITLE
Fix Next.js allowedDevOrigins config

### DIFF
--- a/webapp/next.config.js
+++ b/webapp/next.config.js
@@ -1,8 +1,6 @@
 const { i18n } = require('./next-i18next.config');
-  allowedDevOrigins: ['http://192.168.20.110:3000'],
 module.exports = {
   i18n,
-  allowedDevOrigins: ['http://192.168.20.110:3000'],
   // Para development remoto (ajusta tu IP si cambia):
   allowedDevOrigins: ['http://192.168.20.110:3000'],
 };


### PR DESCRIPTION
## Summary
- restore explanatory comment in `webapp/next.config.js`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `cd webapp && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6840d3f95bd083329a42e112e2f53ea0