### PR TITLE
Fix build script path and deduplicate dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "doc": "docs"
   },
   "scripts": {
-  "build": "rm -rf www/* && cp -R \"APP GoToGym\"/* www/ && echo \"PWA empaquetada en www/\"",
+    "build": "rm -rf www && mkdir -p www && if [ -d webapp/out ]; then cp -R webapp/out/* www/; elif [ -d webapp/.next ]; then cp -R webapp/.next/* www/; fi && echo \"PWA empaquetada en www/\"",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],
@@ -32,12 +32,11 @@
     "swiper": "^11.2.6"
   },
   "devDependencies": {
-  "@capacitor/cli": "^7.2.0",
+    "@capacitor/cli": "^7.2.0",
     "@tailwindcss/forms": "^0.5.10",
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.3",
-    "tailwindcss": "^3.4.17",
-    "@capacitor/cli": "^7.2.0"
+    "tailwindcss": "^3.4.17"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- fix build script to check for Next.js `.next` or `out` directories before copying
- ensure `@capacitor/cli` only appears in `devDependencies`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6840d40d4a7c833289158813a894853e