### PR TITLE
Fix Docker CMD path to backend manage

### DIFF
--- a/Dockerfile.products
+++ b/Dockerfile.products
@@ -13,6 +13,7 @@ COPY . /app/
 
 EXPOSE 8000
 
-# Arrancar el servidor de Django desde la raíz del proyecto
-CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]
+# Arrancar el servidor de Django utilizando el manage.py que se encuentra
+# en el directorio backend
+CMD ["python", "backend/manage.py", "runserver", "0.0.0.0:8000"]
 

--- a/Dockerfile.users
+++ b/Dockerfile.users
@@ -16,6 +16,7 @@ COPY . /app
 # Exponer el puerto 8000
 EXPOSE 8000
 
-# Ejecutar el servidor de Django en 0.0.0.0:8000 para que sea accesible desde fuera del contenedor
-CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]
+# Ejecutar el servidor de Django en 0.0.0.0:8000 utilizando el manage.py
+# ubicado en el directorio backend
+CMD ["python", "backend/manage.py", "runserver", "0.0.0.0:8000"]
 


### PR DESCRIPTION
## Summary
- use backend/manage.py when starting Django server in Docker

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840d41bdb98833282e95d33b1d5a6cf